### PR TITLE
typo in By.ID

### DIFF
--- a/source/waits.rst
+++ b/source/waits.rst
@@ -83,7 +83,7 @@ own utility package for them.
   from selenium.webdriver.support import expected_conditions as EC
 
   wait = WebDriverWait(driver, 10)
-  element = wait.until(EC.element_to_be_clickable((By.Id,'someid')))
+  element = wait.until(EC.element_to_be_clickable((By.ID,'someid')))
 
 The expected_conditions module contains a set of predefined conditions
 to use with WebDriverWait.


### PR DESCRIPTION
AttributeError: type object 'By' has no attribute 'Id'

Correct: By.ID
