### PR TITLE
Update getting-started.rst

### DIFF
--- a/source/getting-started.rst
+++ b/source/getting-started.rst
@@ -169,7 +169,7 @@ case class.  Here you are creating the instance of Firefox WebDriver.
       def setUp(self):
           self.driver = webdriver.Firefox()
 
-This is the test case method.  The first line inside this method
+This is the test case method. The test case method should always start with characters `test`. The first line inside this method
 create a local reference to the driver object created in `setUp`
 method.
 


### PR DESCRIPTION
On line 172 added "The test case method should always start with characters `test`" because I was very confused myself at first when I created a test case whose name did not start with letters 'test' and my test was not running at all.
