### PR TITLE
Update getting-started.rst

### DIFF
--- a/source/getting-started.rst
+++ b/source/getting-started.rst
@@ -118,8 +118,9 @@ for `python.org` search functionality::
           self.assertIn("Python", driver.title)
           elem = driver.find_element_by_name("q")
           elem.send_keys("pycon")
-          assert "No results found." not in driver.page_source
           elem.send_keys(Keys.RETURN)
+          assert "No results found." not in driver.page_source
+          
 
       def tearDown(self):
           self.driver.close()


### PR DESCRIPTION
Lines:

elem.send_keys(Keys.RETURN)
assert "No results found." not in driver.page_source

Lines were opposite in the tutorial on the site as the exist. Gave an error when example shows success. Having tutorial set this way makes sure that desired result happens