### PR TITLE
Update installation Drivers with Selenium Manager and small fixes in API

### DIFF
--- a/source/api.rst
+++ b/source/api.rst
@@ -23,16 +23,32 @@ Then, you can access the classes like this::
 
   webdriver.Firefox
   webdriver.FirefoxProfile
+  webdriver.FirefoxOptions
+  webdriver.FirefoxService
   webdriver.Chrome
   webdriver.ChromeOptions
+  webdriver.ChromeService
   webdriver.Ie
-  webdriver.Opera
-  webdriver.PhantomJS
+  webdriver.IeOptions
+  webdriver.IeService
+  webdriver.Edge
+  webdriver.ChromiumEdge
+  webdriver.EdgeOptions
+  webdriver.EdgeService
+  webdriver.Safari
+  webdriver.SafariOptions
+  webdriver.SafariService
+  webdriver.WebKitGTK
+  webdriver.WebKitGTKOptions
+  webdriver.WebKitGTKService
+  webdriver.WPEWebKit
+  webdriver.WPEWebKitOptions
+  webdriver.WPEWebKitService
   webdriver.Remote
   webdriver.DesiredCapabilities
   webdriver.ActionChains
-  webdriver.TouchActions
   webdriver.Proxy
+  webdriver.Keys
 
 The special keys class (``Keys``) can be imported like this::
 

--- a/source/api.rst
+++ b/source/api.rst
@@ -139,16 +139,6 @@ See the :ref:`selenium-remote-webdriver` section for example usages of desired c
    :member-order: groupwise
    :show-inheritance:
 
-Touch Actions
-~~~~~~~~~~~~~
-
-.. automodule:: selenium.webdriver.common.touch_actions
-   :members:
-   :undoc-members:
-   :special-members: __init__
-   :member-order: groupwise
-   :show-inheritance:
-
 Proxy
 ~~~~~
 
@@ -347,46 +337,6 @@ Internet Explorer WebDriver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: selenium.webdriver.ie.webdriver
-   :members:
-   :undoc-members:
-   :special-members: __init__
-   :member-order: groupwise
-   :show-inheritance:
-
-Android WebDriver
-~~~~~~~~~~~~~~~~~
-
-.. automodule:: selenium.webdriver.android.webdriver
-   :members:
-   :undoc-members:
-   :special-members: __init__
-   :member-order: groupwise
-   :show-inheritance:
-
-Opera WebDriver
-~~~~~~~~~~~~~~~
-
-.. automodule:: selenium.webdriver.opera.webdriver
-   :members:
-   :undoc-members:
-   :special-members: __init__
-   :member-order: groupwise
-   :show-inheritance:
-
-PhantomJS WebDriver
-~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: selenium.webdriver.phantomjs.webdriver
-   :members:
-   :undoc-members:
-   :special-members: __init__
-   :member-order: groupwise
-   :show-inheritance:
-
-PhantomJS WebDriver Service
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: selenium.webdriver.phantomjs.service
    :members:
    :undoc-members:
    :special-members: __init__

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -111,7 +111,7 @@ the more popular browser drivers follow.
 
 For more information about driver installation, please refer the `official
 documentation
-<https://www.selenium.dev/documentation/en/webdriver/driver_requirements/>`_.
+<https://www.selenium.dev/documentation/webdriver/>`_.
 
 
 Downloading Selenium server

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -113,6 +113,26 @@ For more information about driver installation, please refer the `official
 documentation
 <https://www.selenium.dev/documentation/webdriver/>`_.
 
+Starting from version ``4.6.0`` (November 4, 2022)
+selenium comes with **Selenium Manager** packed in distribution.
+
+**Selenium Manager** is a new tool that helps to get a working environment
+to run **Selenium** out of the box:
+
+* automatically discovers, downloads, and caches the ``drivers``
+  required by Selenium when these ``drivers`` are unavailable;
+* automatically discovers, downloads, and caches the ``browsers``
+  driven with Selenium (Chrome, Firefox, and Edge)
+  when these ``browsers`` are not installed in the local system.
+
+For example, to see the result of **Selenium Manager** work
+just run any selenium script without previous driver setup
+and explore `~/.cache/selenium`.
+
+More about **Selenium Manager** you can read in the
+`documentation <https://www.selenium.dev/documentation/selenium_manager/>`_
+and
+`blog <https://www.selenium.dev/blog/2022/introducing-selenium-manager/>`_.
 
 Downloading Selenium server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Selenium Manager

Added info about **Selenium Manager** in `installation.drivers` section.

- https://www.selenium.dev/documentation/selenium_manager/
- https://www.selenium.dev/blog/2022/introducing-selenium-manager/

## API
Deleted auto doc for modules  that do not longer exist like `PhantomJS`.

> WARNING: autodoc: failed to import module 'phantomjs.webdriver' from module 'selenium.webdriver'; the following exception was raised:
> No module named 'selenium.webdriver.phantomjs'

Updated `selenium.webdriver` imports from current `__all__` list.