### PR TITLE
Update the page objects documentation to use the newer syntax for finding elements by name.

### DIFF
--- a/source/page-objects.rst
+++ b/source/page-objects.rst
@@ -118,6 +118,7 @@ Page elements
 
 The ``element.py`` will look like this::
 
+  from selenium.webdriver.common.by import By
   from selenium.webdriver.support.ui import WebDriverWait
 
 
@@ -129,17 +130,17 @@ The ``element.py`` will look like this::
 
           driver = obj.driver
           WebDriverWait(driver, 100).until(
-              lambda driver: driver.find_element_by_name(self.locator))
-          driver.find_element_by_name(self.locator).clear()
-          driver.find_element_by_name(self.locator).send_keys(value)
+              lambda driver: driver.find_element(By.NAME, self.locator))
+          driver.find_element(By.NAME, self.locator).clear()
+          driver.find_element(By.NAME, self.locator).send_keys(value)
 
       def __get__(self, obj, owner):
           """Gets the text of the specified object"""
 
           driver = obj.driver
           WebDriverWait(driver, 100).until(
-              lambda driver: driver.find_element_by_name(self.locator))
-          element = driver.find_element_by_name(self.locator)
+              lambda driver: driver.find_element(By.NAME, self.locator))
+          element = driver.find_element(By.NAME, self.locator)
           return element.get_attribute("value")
 
 


### PR DESCRIPTION

This follows-up the changes done in:
* PR https://github.com/baijum/selenium-python/pull/99
* commit 3b13c2f8f864c2b4a56fb5dddebab0cd86817ad6